### PR TITLE
feat(link-group): 为链接组添加图标设置功能

### DIFF
--- a/annotation-setting.yaml
+++ b/annotation-setting.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1alpha1
+kind: AnnotationSetting
+metadata:
+  generateName: annotation-setting-
+spec:
+  targetRef:
+    group: core.halo.run
+    kind: LinkGroup
+  formSchema:
+    - $formkit: text
+      name: "icon"
+      label: "图标"
+      help: "图标名称，支持所有 iconify 图标。例如 https://icones.netlify.app/"

--- a/templates/links.html
+++ b/templates/links.html
@@ -21,7 +21,13 @@
             <div
               class="blur-before flex items-center gap-1 py-14 font-bold text-zinc-600 after:ml-2 after:h-0 after:flex-1 after:border-b after:border-dashed after:border-zinc-100 after:content-[''] sm:py-8 dark:text-zinc-200 after:dark:border-zinc-700/40"
             >
+              <span
+                th:if="${#annotations.contains(group, 'icon') and #annotations.get(group, 'icon') != ''}"
+                class="iconify h-6 w-6"
+                th:data-icon="${#annotations.get(group, 'icon')}"
+              ></span>
               <svg
+                th:unless="${#annotations.contains(group, 'icon') and #annotations.get(group, 'icon') != ''}"
                 xmlns="http://www.w3.org/2000/svg"
                 width="24"
                 height="24"


### PR DESCRIPTION
- 新增 AnnotationSetting 资源，用于设置链接组的图标
- 在链接组模板中添加图标显示逻辑，支持自定义图标
- 默认使用内置图标

预览：

<img width="1540" height="1229" alt="image" src="https://github.com/user-attachments/assets/03f683b3-ec8e-437d-a798-f04cef8e6093" />
