### PR TITLE
feat(links): 为链接和链接组添加私密功能

### DIFF
--- a/annotation-setting.yaml
+++ b/annotation-setting.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1alpha1
+kind: AnnotationSetting
+metadata:
+  generateName: annotation-setting-
+spec:
+  targetRef:
+    group: core.halo.run
+    kind: LinkGroup
+  formSchema:
+    - $formkit: checkbox
+      name: "hide"
+      label: "隐藏"
+      value: "false"
+      on-value: "true"
+      off-value: "false"
+---
+apiVersion: v1alpha1
+kind: AnnotationSetting
+metadata:
+  generateName: annotation-setting-
+spec:
+  targetRef:
+    group: core.halo.run
+    kind: Link
+  formSchema:
+    - $formkit: checkbox
+      name: "hide"
+      label: "隐藏"
+      value: "false"
+      on-value: "true"
+      off-value: "false"

--- a/templates/links.html
+++ b/templates/links.html
@@ -17,7 +17,7 @@
               </span>
             </p>
           </header>
-          <th:block th:each="group : ${groups}">
+          <th:block th:each="group : ${groups}" th:if="${#annotations.getOrDefault(group, 'hide','false') == 'false'}">
             <div
               class="blur-before flex items-center gap-1 py-14 font-bold text-zinc-600 after:ml-2 after:h-0 after:flex-1 after:border-b after:border-dashed after:border-zinc-100 after:content-[''] sm:py-8 dark:text-zinc-200 after:dark:border-zinc-700/40"
             >
@@ -41,7 +41,10 @@
               <span>[[${group.spec.displayName}]]</span>
             </div>
             <ul class="page-links grid grid-cols-1 gap-x-12 gap-y-16 sm:grid-cols-2 lg:grid-cols-3">
-              <th:block th:each="link : ${group.links}">
+              <th:block
+                th:each="link : ${group.links}"
+                th:if="${#annotations.getOrDefault(link, 'hide','false') == 'false'}"
+              >
                 <th:block id="123" th:replace="~{modules/favlink-item  :: favlink-item(${link})}" />
               </th:block>
             </ul>


### PR DESCRIPTION
- 新增 AnnotationSetting 资源，为 LinkGroup 和 Link 添加隐藏选项

## 预览：

### 隐藏链接组

<img width="1540" height="1229" alt="image" src="https://github.com/user-attachments/assets/c0c09dc2-759f-4928-ae4e-116d6cd55589" />
<img width="1540" height="1229" alt="image" src="https://github.com/user-attachments/assets/82e37df6-3031-42e0-89af-768c0f7a392b" />


### 隐藏单链接

<img width="1540" height="1229" alt="image" src="https://github.com/user-attachments/assets/e5c6c4b5-781d-432f-a255-40075e86f86f" />

