### PR TITLE
fix: 修复在Markdown模式下编辑表格后，页面渲染不正常的问题

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -160,6 +160,10 @@ spec:
           language: html
           value: '<p style="font-weight: 400;">很高兴能和非常多的朋友们交流，如果你也想加入友链，可以点击下方添加按钮进行申请。<mark>（本站已开启友链提交自动审核，您的链接将会第一时间被添加。）</mark></p><div style="height:1rem" aria-hidden="true" class="wp-block-spacer"></div><ul class="wp-block-list thyuu-block"><li>1. 交流互动并且保持联系（重点）；</li><li>2. 至少有 10 篇原创文章；</li><li>3. 请提前做好本站链接。</li></ul>'
         - $formkit: text
+          name: subtitle
+          label: 简述
+          validation: required
+        - $formkit: text
           name: admin_email
           label: 邮箱
           validation: required

--- a/templates/assets/js/function.js
+++ b/templates/assets/js/function.js
@@ -282,9 +282,27 @@ function postMarkHighlight(){
 }
 
 function postTableHighlight(){
-  document.querySelectorAll('.prose table').forEach(el => {
-    el.parentNode.setAttribute('class','wp-block-table')
-  });
+  let tableDomList = document.querySelectorAll('.prose table');
+  let postType = '';
+  // 通过表格元素的父元素id是否为content判断文章是Markdown格式编写的还是富文本编辑器编写的
+  // 只需要取其中一个判断即可
+  if (tableDomList.length > 0) {
+    postType = tableDomList[0].parentNode.id === 'content' ? 'Markdown' : 'RichText';
+  }
+  // 如果是Markdown，则需要在表格外再套一层div
+  if (postType === 'Markdown') {
+    tableDomList.forEach(el => {
+      const wrapper = document.createElement('div');
+      wrapper.classList.add('wp-block-table');
+      wrapper.style.overflow = 'auto hidden';
+      el.parentNode.insertBefore(wrapper, el);
+      wrapper.appendChild(el);
+    });
+  } else {
+    tableDomList.forEach(el => {
+      el.parentNode.classList.add('wp-block-table');
+    });
+  }
 }
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/templates/links.html
+++ b/templates/links.html
@@ -68,7 +68,7 @@
             <summary>我的友链信息</summary>
             <ul id="copy" class="space-y-2 text-sm">
               <li class="flex gap-2"><span class="text-lime-500">站名</span><em th:text="${site.title}"></em></li>
-              <li class="flex gap-2"><span class="text-lime-500">简述</span><em th:text="${site.subtitle}"></em></li>
+              <li class="flex gap-2"><span class="text-lime-500">简述</span><em th:text="${theme.config.links.subtitle}"></em></li>
               <li class="flex gap-2">
                 <span class="text-lime-500">邮箱</span><em th:text="${theme.config.links.admin_email}"></em>
               </li>

--- a/templates/links.html
+++ b/templates/links.html
@@ -77,7 +77,8 @@
                 <span class="text-lime-500">订阅</span><em th:text="${site.url+'/rss.xml'}"></em>
               </li>
               <li class="flex gap-2">
-                <span class="text-lime-500">标识</span><em th:text="${site.url+site.logo}"></em>
+                <span class="text-lime-500">标识</span>
+                <em th:text="${site.logo.startsWith('http') ? site.logo : site.url + site.logo}"></em>
               </li>
             </ul>
           </details>


### PR DESCRIPTION
满足以下条件，即可触发该Bug：
1. 使用了Markdown编辑器
2. 文章中有表格

如果是Markdown编辑器编辑的文章，在渲染页面时，Halo并没有在表格的外层套一个div，他的父div就是整个正文内容的div，直接给这个div设置wp-block-table样式会导致整个正文渲染异常