### PR TITLE
fix: 修复博客友链页面点击提交友联后新增或更新传递参数错误导致操作失败的问题

### DIFF
--- a/templates/modules/add-link.html
+++ b/templates/modules/add-link.html
@@ -207,10 +207,11 @@
                   type: type,
                   displayName: displayName,
                   url: url,
+                  oldUrl: oldUrl,
                   logo: logo,
                   email: email,
                   description: description,
-                  updateDescription: updateDescription,
+                  updateDescription: description,
                   groupName: groupName,
                 }),
               })


### PR DESCRIPTION
修复博客友链页面点击提交友联后新增或更新传递参数错误导致操作失败的问题