### PR TITLE
fix: 修复post页面渲染图片的问题

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -261,7 +261,7 @@
     /**
      * 给img增加一些装饰
      */
-    document.querySelectorAll(".prose p>img").forEach((el) => {
+    document.querySelectorAll(".prose p>img, .prose li>img").forEach((el) => {
       if (!el.getAttribute("data-fancybox")) {
         const classes = el.class;
         el.setAttribute(
@@ -269,8 +269,11 @@
           "relative z-20 dark:brightness-75 dark:transition-[filter] rounded-xl dark:hover:brightness-100 rounded-xl" +
             classes
         );
-        el.parentNode.setAttribute("class", "rounded-2xl bg-zinc-100 p-2 dark:bg-zinc-800");
         el.setAttribute("data-fancybox", "images");
+        const wrapper = document.createElement("div");
+        wrapper.setAttribute("class", "rounded-2xl bg-zinc-100 p-2 dark:bg-zinc-800 w-fit");
+        el.parentNode.insertBefore(wrapper, el);
+        wrapper.appendChild(el);
         const altText = el.getAttribute("alt");
         if (!altText) return;
         const span = document.createElement("span");


### PR DESCRIPTION
1. 修复当图片本身宽度较小时，背景依然100%的宽度显示为灰色，现在缩小为根据图片大小自适应
2. 同时给图片套一层div，防止Markdown格式文章渲染时有概率把上一行文字也当作图片背景渲染到背景阴影里
3. 修复当Markdown格式文章中无序列内有图片时不渲染的问题