### PR TITLE
fix: 修复手机端页头前往按钮中文字在某些屏幕尺寸下会换行的问题

### DIFF
--- a/templates/modules/header.html
+++ b/templates/modules/header.html
@@ -25,7 +25,7 @@
           data-headlessui-state=""
           @click="showMobileNav = !showMobileNav"
         >
-          前往 <i class="iconfont icon-caret-down-solid ml-1 !text-xs !leading-[1]"></i>
+          <span class="w-[2em]">前往</span><i class="iconfont icon-caret-down-solid ml-1 !text-xs !leading-[1]"></i>
         </button>
         <!-- panel -->
         <template x-teleport="body">


### PR DESCRIPTION
修复手机端页头前往按钮中文字在某些屏幕尺寸下会换行的问题
<img width="360" height="519" alt="image" src="https://github.com/user-attachments/assets/f8bc7f44-b86e-4487-a4d7-db00524e196f" />
