### PR TITLE
feat: 支持在Markdown中自定义超链接卡片显示的标题

### DIFF
--- a/src/functions/links/index.ts
+++ b/src/functions/links/index.ts
@@ -99,15 +99,35 @@ export function replaceLinksInElement(container: HTMLElement | null) {
     let newLinkHTML = "";
     // 默认新窗口打开
     target = target.length == 0 ? "_blank" : target;
+    let title = "";
+    // 从 text 中提取#前面的字符作为标题
+    if (text.length != 0) {
+      const index = text.indexOf("#");
+      if (index >= 0) {
+        // markdown 内容为 [测试#small](xxx) 或 [#small](xxx)
+        title = `custom-title="${text.substring(0, index)}"`;
+      } else {
+        // markdown 内容为 [测试](xxx)
+        title = `custom-title="${text}"`;
+      }
+    }
 
     if (text.includes("#regular")) {
-      newLinkHTML = `<hyperlink-card href="${escapeHtml(href)}" target="${target}" theme="regular"></hyperlink-card>`;
+      newLinkHTML = `<hyperlink-card href="${escapeHtml(
+        href
+      )}" target="${target}" theme="regular" ${title}></hyperlink-card>`;
     } else if (text.includes("#small")) {
-      newLinkHTML = `<hyperlink-card href="${escapeHtml(href)}" target="${target}" theme="small"></hyperlink-card>`;
+      newLinkHTML = `<hyperlink-card href="${escapeHtml(
+        href
+      )}" target="${target}" theme="small" ${title}></hyperlink-card>`;
     } else if (text.includes("#grid")) {
-      newLinkHTML = `<hyperlink-card href="${escapeHtml(href)}" target="${target}" theme="grid"></hyperlink-card>`;
+      newLinkHTML = `<hyperlink-card href="${escapeHtml(
+        href
+      )}" target="${target}" theme="grid" ${title}></hyperlink-card>`;
     } else {
-      newLinkHTML = `<hyperlink-inline-card href="${escapeHtml(href)}" target="${target}"></hyperlink-inline-card>`;
+      newLinkHTML = `<hyperlink-inline-card href="${escapeHtml(
+        href
+      )}" target="${target}" ${title}></hyperlink-inline-card>`;
     }
 
     // 创建临时容器并插入新元素


### PR DESCRIPTION
## 新增功能
支持在Markdown中自定义超链接卡片显示的标题
Markdown 中方括号里可以自定义填写超链接显示内容，自动渲染到超链接卡片的标题上

## 使用示例
### Markdown 内容
<img width="412" height="397" alt="image" src="https://github.com/user-attachments/assets/3b37dbf1-9b7d-4403-a5cd-9274916ea773" />

### 不指定标题 (自动抓取网站标题)
<img width="537" height="545" alt="image" src="https://github.com/user-attachments/assets/70da1fa7-c2e3-49a2-a50b-05b666d4cbd8" />

### 指定标题
<img width="544" height="558" alt="image" src="https://github.com/user-attachments/assets/2f93e880-0997-4995-91cc-5ad32c531396" />
